### PR TITLE
Rewrite to use HostAddress rather than InputAddress.

### DIFF
--- a/src/Client/Program.cs
+++ b/src/Client/Program.cs
@@ -33,12 +33,13 @@
 
             TaskUtil.Await(() => busControl.StartAsync());
 
+            Uri hostAddress = busControl.Address.GetHostSettings().HostAddress;
+
             string validateQueueName = ConfigurationManager.AppSettings["ValidateActivityQueue"];
-            Uri validateAddress = new Uri(string.Concat(busControl.Address, validateQueueName));
+            Uri validateAddress = new Uri(string.Concat(hostAddress, validateQueueName));
 
             string retrieveQueueName = ConfigurationManager.AppSettings["RetrieveActivityQueue"];
-
-            Uri retrieveAddress = new Uri(string.Concat(busControl.Address, retrieveQueueName));
+            Uri retrieveAddress = new Uri(string.Concat(hostAddress, retrieveQueueName));
 
 
             try


### PR DESCRIPTION
In PR #3 an issue was introduced due to the misuse of busControl.Address which yields a different result than _host.GetSendAddress used to. I leveraged busControl.Address.GetHostSettings rather than using the ConfigurationManager because I feel it's cleaner accessing the host that way.

This also solves Issue #4.